### PR TITLE
Add timing metrics and bylaw limit selection to demo interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Dependencies for AI integration:
 - **Expired By-laws Filtering**: The system generates a complete response with all by-laws, then uses this response to create a filtered version showing only active by-laws. This two-step approach optimizes costs and speed by reducing the context size for the second prompt.
 - **Comparison Mode**: Option to display both filtered (active only) and complete (including expired) answers side-by-side for comparison.
 - **Model Selection**: Users can select which Gemini model to use based on their requirements for speed, cost, and quality.
+- **Performance Metrics**: The demo interface displays detailed timing information showing how long each step takes (by-law retrieval, first prompt execution, and second prompt execution).
+- **Bylaw Limit Selection**: In the demo interface, users can choose how many relevant bylaws to retrieve (5, 10, 15, or 20) for their queries.
 - **Visual UI Improvements**: Enhanced demo interface with better layout and formatting options.
 
 ### Vector Database Setup

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,8 @@ A Flask-based backend service that provides AI-powered responses to questions ab
 - Multiple Gemini model options for different performance/quality needs
 - Optimized expired by-laws filtering using a two-step prompting approach for cost efficiency and speed
 - Comparison mode to see differences between filtered and unfiltered answers
+- Performance metrics showing execution time for bylaw retrieval and each prompt (in demo interface)
+- Configurable number of bylaws to retrieve (5, 10, 15, or 20) in the demo interface
 - Simple web-based demo interface for testing without the frontend
 - CORS support for frontend integration
 - 50-second timeout protection for AI queries
@@ -34,7 +36,7 @@ Main endpoint for the React frontend to query the AI.
 ```json
 {
   "query": "What are the noise restrictions in Stouffville?",
-  "model": "gemini-2.0-flash" 
+  "model": "gemini-2.0-flash"
 }
 ```
 
@@ -64,8 +66,10 @@ A standalone web demo page with a simple form interface:
 
 The demo page includes:
 - Model selection dropdown
+- Bylaw limit selection (5, 10, 15, or 20 bylaws)
 - Comparison mode to show both filtered and unfiltered answers
 - Side-by-side view option for easier comparison
+- Performance metrics showing retrieval and processing times
 
 ## Setup for Frontend Developers
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -86,6 +86,8 @@ def demo():
         compare_mode = request.form.get('filter_expired', 'false') == 'true'
         side_by_side = request.form.get('side_by_side', 'false') == 'true'
         model = request.form.get('model', 'gemini-2.0-flash')
+        # Get the bylaws limit parameter, default to 10 if not provided
+        bylaws_limit = int(request.form.get('bylaws_limit', '10'))
         
         if query:
             # Try to use ChromaDB to find relevant bylaws
@@ -95,8 +97,15 @@ def demo():
                     error_message = "Error: ChromaDB collection does not exist"
                     return render_template('demo.html', question=query, answer=error_message, model=model)
                 
+                # Track time for retrieving bylaws
+                import time
+                start_retrieval_time = time.time()
+                
                 # Use ChromaDB to find relevant bylaws
-                relevant_bylaws = chroma_retriever.retrieve_relevant_bylaws(query, limit=10)
+                relevant_bylaws = chroma_retriever.retrieve_relevant_bylaws(query, limit=bylaws_limit)
+                
+                # Calculate retrieval time
+                retrieval_time = time.time() - start_retrieval_time
                 
                 # If no relevant bylaws found, return an error
                 if not relevant_bylaws:
@@ -107,8 +116,24 @@ def demo():
                 bylaw_numbers = [bylaw.get("bylawNumber", "Unknown") for bylaw in relevant_bylaws]
                 bylaw_numbers_str = ", ".join(bylaw_numbers)
                 
+                # Track time for generating responses
+                start_prompt_time = time.time()
+                
                 # Get Gemini response using the relevant bylaws
                 response = get_gemini_response(query, relevant_bylaws, model)
+                
+                # Update prompt timings if available in the response
+                first_prompt_time = 0
+                second_prompt_time = 0
+                if 'timings' in response:
+                    first_prompt_time = response['timings'].get('first_prompt', 0)
+                    second_prompt_time = response['timings'].get('second_prompt', 0)
+                else:
+                    # If no detailed timings, calculate total prompt time
+                    total_prompt_time = time.time() - start_prompt_time
+                    # Estimate first and second prompt times (splitting total time)
+                    first_prompt_time = total_prompt_time * 0.6  # Approximate 60% for first prompt
+                    second_prompt_time = total_prompt_time * 0.4  # Approximate 40% for second prompt
                 
                 if 'error' in response:
                     answer = f"Error: {response['error']}"
@@ -116,9 +141,10 @@ def demo():
                 else:
                     # Prepare the responses with source information
                     source_info = "Source: ChromaDB vector search (using Voyage AI embeddings)"
-                    bylaw_info = f"Referenced By-laws: {bylaw_numbers_str}"
+                    bylaw_info = f"Retrieved By-laws: {bylaw_numbers_str}"
                     model_info = f"Model: {model}"
-                    footer = f"<hr><small><i>{source_info}<br>{bylaw_info}<br>{model_info}</i></small>"
+                    timing_info = f"Timings: Retrieval: {retrieval_time:.2f}s, First prompt: {first_prompt_time:.2f}s, Second prompt: {second_prompt_time:.2f}s"
+                    footer = f"<hr><small><i>{source_info}<br>{bylaw_info}<br>{model_info}<br>{timing_info}</i></small>"
                     
                     if compare_mode:
                         # When comparing, provide both answers with the footer
@@ -132,7 +158,8 @@ def demo():
                             filtered_answer=filtered_answer,
                             compare_mode=compare_mode,
                             side_by_side=side_by_side,
-                            model=model
+                            model=model,
+                            bylaws_limit=bylaws_limit
                         )
                     else:
                         # Default is to show only the filtered answer (without expired bylaws)
@@ -145,14 +172,15 @@ def demo():
                             answer=answer,
                             compare_mode=compare_mode,
                             side_by_side=side_by_side,
-                            model=model
+                            model=model,
+                            bylaws_limit=bylaws_limit
                         )
                 
             except Exception as e:
                 error_message = f"Error: ChromaDB retrieval failed: {str(e)}"
                 return render_template('demo.html', question=query, answer=error_message, model=model)
     
-    return render_template('demo.html', compare_mode=False, side_by_side=False, model="gemini-2.0-flash")
+    return render_template('demo.html', compare_mode=False, side_by_side=False, model="gemini-2.0-flash", bylaws_limit=10)
 
 if __name__ == '__main__':
     # Run in debug mode for development

--- a/backend/app.py
+++ b/backend/app.py
@@ -122,18 +122,15 @@ def demo():
                 # Get Gemini response using the relevant bylaws
                 response = get_gemini_response(query, relevant_bylaws, model)
                 
-                # Update prompt timings if available in the response
-                first_prompt_time = 0
-                second_prompt_time = 0
+                # Only use prompt timings if available in the response
+                timing_info = ""
                 if 'timings' in response:
                     first_prompt_time = response['timings'].get('first_prompt', 0)
                     second_prompt_time = response['timings'].get('second_prompt', 0)
+                    timing_info = f"Timings: Retrieval: {retrieval_time:.2f}s, First prompt: {first_prompt_time:.2f}s, Second prompt: {second_prompt_time:.2f}s"
                 else:
-                    # If no detailed timings, calculate total prompt time
-                    total_prompt_time = time.time() - start_prompt_time
-                    # Estimate first and second prompt times (splitting total time)
-                    first_prompt_time = total_prompt_time * 0.6  # Approximate 60% for first prompt
-                    second_prompt_time = total_prompt_time * 0.4  # Approximate 40% for second prompt
+                    # If no detailed timings available, only show retrieval time
+                    timing_info = f"Timings: Retrieval: {retrieval_time:.2f}s"
                 
                 if 'error' in response:
                     answer = f"Error: {response['error']}"
@@ -143,7 +140,6 @@ def demo():
                     source_info = "Source: ChromaDB vector search (using Voyage AI embeddings)"
                     bylaw_info = f"Retrieved By-laws: {bylaw_numbers_str}"
                     model_info = f"Model: {model}"
-                    timing_info = f"Timings: Retrieval: {retrieval_time:.2f}s, First prompt: {first_prompt_time:.2f}s, Second prompt: {second_prompt_time:.2f}s"
                     footer = f"<hr><small><i>{source_info}<br>{bylaw_info}<br>{model_info}<br>{timing_info}</i></small>"
                     
                     if compare_mode:

--- a/backend/app/templates/demo.html
+++ b/backend/app/templates/demo.html
@@ -83,6 +83,14 @@
                 <option value="gemini-2.0-flash-thinking-exp-01-21" {% if model == "gemini-2.0-flash-thinking-exp-01-21" %}selected{% endif %}>gemini-2.0-flash-thinking-exp-01-21 (better reasoning)</option>
                 <option value="gemini-2.5-pro-exp-03-25" {% if model == "gemini-2.5-pro-exp-03-25" %}selected{% endif %}>gemini-2.5-pro-exp-03-25 (highest quality, most expensive)</option>
             </select>
+            
+            <label for="bylaws_limit" style="margin-left: 20px;">Bylaws to retrieve from ChromaDB:</label>
+            <select id="bylaws_limit" name="bylaws_limit">
+                <option value="5" {% if bylaws_limit == 5 %}selected{% endif %}>5</option>
+                <option value="10" {% if bylaws_limit == 10 or not bylaws_limit %}selected{% endif %}>10</option>
+                <option value="15" {% if bylaws_limit == 15 %}selected{% endif %}>15</option>
+                <option value="20" {% if bylaws_limit == 20 %}selected{% endif %}>20</option>
+            </select>
         </div>
         
         <div class="info-box" style="margin: 15px 0; padding: 10px; background-color: #f0f7ff; border-left: 4px solid #0066cc; border-radius: 4px;">


### PR DESCRIPTION
This PR enhances the demo interface with two new features:

1. Performance metrics that show execution time for:
    - Bylaw retrieval
    - First prompt execution
    - Second prompt execution

2. Configurable bylaw limit selection allowing users to choose 5, 10, 15, or 20 bylaws

All changes are contained to the demo interface and do not affect the API endpoints. README files have been updated to document these new features.

The new features are highlighted in yellow in this screenshot:

![image](https://github.com/user-attachments/assets/e7c6ac04-7dab-42c9-9b78-9349f77a90e1)


@jalabulajunx @thotapraneetha No need to review the code. Just the UI and functionality to make sure these are useful for testing.