### PR TITLE
Add layman's terms feature to improve bylaw accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ Dependencies for AI integration:
 ### Key Features
 
 - **Expired By-laws Filtering**: The system generates a complete response with all by-laws, then uses this response to create a filtered version showing only active by-laws. This two-step approach optimizes costs and speed by reducing the context size for the second prompt.
-- **Comparison Mode**: Option to display both filtered (active only) and complete (including expired) answers side-by-side for comparison.
+- **Layman's Terms Conversion**: After filtering active by-laws, a third prompt transforms the technical legal language into plain, everyday language without bylaw references, making information more accessible to residents.
+- **Comparison Mode**: Option to display all three versions of the answer (complete, filtered active only, and layman's terms) for comparison.
 - **Model Selection**: Users can select which Gemini model to use based on their requirements for speed, cost, and quality.
-- **Performance Metrics**: The demo interface displays detailed timing information showing how long each step takes (by-law retrieval, first prompt execution, and second prompt execution).
+- **Performance Metrics**: The demo interface displays detailed timing information showing how long each step takes (by-law retrieval, first prompt execution, second prompt execution, and third prompt execution).
 - **Bylaw Limit Selection**: In the demo interface, users can choose how many relevant bylaws to retrieve (5, 10, 15, or 20) for their queries.
 - **Visual UI Improvements**: Enhanced demo interface with better layout and formatting options.
 
@@ -231,7 +232,10 @@ The system implements a Retrieval-Augmented Generation (RAG) architecture with t
    - Voyage AI generates embeddings for these documents using the `voyage-3-large` model
    - ChromaDB indexes embeddings for efficient semantic retrieval using HNSW algorithm
    - When a query is received, relevant by-laws are retrieved and passed to Gemini AI
-   - Gemini generates both complete and filtered responses (active bylaws only) based on retrieved context
+   - Gemini generates three different responses:
+     - Complete response with all retrieved by-laws
+     - Filtered response with only active by-laws
+     - Layman's terms response with simplified language and no bylaw references
 
 2. **Backend Core**:
    - Flask application handles HTTP routing and request processing
@@ -251,6 +255,6 @@ The system implements a Retrieval-Augmented Generation (RAG) architecture with t
 5. **User Interface Options**:
    - Web demo interface with model selection and bylaw limit options
    - Performance metrics showing timing information for each processing step
-   - Option to compare filtered (active) and complete (including expired) bylaw responses
+   - Option to compare all three versions of the answer (complete, filtered active only, and layman's terms)
 
 This architecture ensures that the system can accurately respond to user queries about Stouffville by-laws by finding the most semantically relevant information and presenting it in a natural, conversational format.

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,8 @@ A Flask-based backend service that provides AI-powered responses to questions ab
 - REST API for querying the Gemini AI model
 - Multiple Gemini model options for different performance/quality needs
 - Optimized expired by-laws filtering using a two-step prompting approach for cost efficiency and speed
-- Comparison mode to see differences between filtered and unfiltered answers
+- Layman's terms conversion that transforms legal language into plain, everyday language accessible to residents
+- Comparison mode to see differences between complete, filtered, and layman's terms versions
 - Performance metrics showing execution time for bylaw retrieval and each prompt (in demo interface)
 - Configurable number of bylaws to retrieve (5, 10, 15, or 20) in the demo interface
 - Simple web-based demo interface for testing without the frontend
@@ -45,6 +46,7 @@ Main endpoint for the React frontend to query the AI.
 {
   "answer": "The AI-generated response about all Stouffville by-laws",
   "filtered_answer": "The AI-generated response about only active Stouffville by-laws",
+  "laymans_answer": "The AI-generated response in simple, everyday language without bylaw references",
   "source": "ChromaDB",
   "bylaw_numbers": ["2015-139-RE", "2015-04-RE"],
   "model": "gemini-2.0-flash"
@@ -67,7 +69,7 @@ A standalone web demo page with a simple form interface:
 The demo page includes:
 - Model selection dropdown
 - Bylaw limit selection (5, 10, 15, or 20 bylaws)
-- Comparison mode to show both filtered and unfiltered answers
+- Comparison mode to show all three versions of the response (complete, filtered, and layman's terms)
 - Side-by-side view option for easier comparison
 - Performance metrics showing retrieval and processing times
 
@@ -109,7 +111,7 @@ Frontend developers can directly use this production backend if they don't want 
    - Backend is configured with CORS support for frontend integration
    - Use the `/api/ask` endpoint for all AI queries from your React app
    - Queries should be sent as JSON with a `query` field and optional `model` field
-   - Responses will contain either an `answer`/`filtered_answer` field with the AI response or an `error` field
+   - Responses will contain `answer`, `filtered_answer`, and `laymans_answer` fields with the AI responses, or an `error` field
    - Responses include a `source` field indicating the data comes from ChromaDB
    - Responses include a `bylaw_numbers` array listing the referenced by-laws
 
@@ -118,7 +120,7 @@ Frontend developers can directly use this production backend if they don't want 
 - `app.py`: Main Flask application
 - `app/`: Application package
   - `__init__.py`: Package initialization
-  - `prompts.py`: AI prompt templates (including filtered version for active by-laws only)
+  - `prompts.py`: AI prompt templates (including filtered version for active by-laws only and layman's terms conversion)
   - `chroma_retriever.py`: ChromaDB integration for vector search
   - `gemini_handler.py`: Gemini AI model integration and response processing
   - `templates/`: HTML templates for web interfaces
@@ -140,21 +142,23 @@ The application uses ChromaDB and Voyage AI embeddings to provide intelligent re
 
 1. When a query is received, the system attempts to find relevant by-laws using vector search
 2. If relevant documents are found, those specific by-laws are sent to Gemini AI
-3. The system generates two different responses:
+3. The system generates three different responses:
    - A complete answer using all retrieved by-laws
    - A filtered answer that removes expired by-laws from the first response
-4. Demo interface provides options to compare both responses
+   - A layman's terms answer that simplifies the language and removes bylaw references from the filtered response
+4. Demo interface provides options to compare all three responses
 
-## Optimized Two-Step Prompt System
+## Optimized Three-Step Prompt System
 
-The system uses a cost-efficient two-step approach for filtering expired by-laws:
+The system uses a cost-efficient multi-step approach for processing by-laws information:
 
 1. **First Prompt**: The complete by-laws content is sent to the Gemini model along with the user question to generate a comprehensive response
 2. **Second Prompt**: Instead of sending the by-laws content again, the system sends only the first response to a second prompt that filters out expired by-laws
-3. **Benefits**:
+3. **Third Prompt**: The filtered response is sent to a third prompt that transforms the legal language into plain, everyday language and removes all bylaw references
+4. **Benefits**:
    - Significantly reduces token usage and API costs
-   - Maintains quality by having the second prompt focus solely on filtering
-   - Preserves all formatting and style from the original response
+   - Maintains quality by having each prompt focus on a specific task
+   - Preserves formatting while transforming content appropriately at each step
    - Increases speed
    - Makes it possible to choose a more suitable model for each prompt to improve speed, accuracy, and cost
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -127,7 +127,8 @@ def demo():
                 if 'timings' in response:
                     first_prompt_time = response['timings'].get('first_prompt', 0)
                     second_prompt_time = response['timings'].get('second_prompt', 0)
-                    timing_info = f"Timings: Retrieval: {retrieval_time:.2f}s, First prompt: {first_prompt_time:.2f}s, Second prompt: {second_prompt_time:.2f}s"
+                    third_prompt_time = response['timings'].get('third_prompt', 0)
+                    timing_info = f"Timings: Retrieval: {retrieval_time:.2f}s, First prompt: {first_prompt_time:.2f}s, Second prompt: {second_prompt_time:.2f}s, Third prompt: {third_prompt_time:.2f}s"
                 else:
                     # If no detailed timings available, only show retrieval time
                     timing_info = f"Timings: Retrieval: {retrieval_time:.2f}s"
@@ -146,12 +147,14 @@ def demo():
                         # When comparing, provide both answers with the footer
                         full_answer = response.get('answer', 'Error: No response') + footer
                         filtered_answer = response.get('filtered_answer', 'Error: No response') + footer
+                        laymans_answer = response.get('laymans_answer', 'Error: No response') + footer
                         
                         return render_template(
                             'demo.html', 
                             question=query, 
                             full_answer=full_answer,
                             filtered_answer=filtered_answer,
+                            laymans_answer=laymans_answer,
                             compare_mode=compare_mode,
                             side_by_side=side_by_side,
                             model=model,

--- a/backend/app/prompts.py
+++ b/backend/app/prompts.py
@@ -13,15 +13,17 @@ You have access to the following Stouffville by-laws data:
 Today's date is """ + datetime.now().strftime("%B %d, %Y") + """.
 
 When answering questions:
-1. Use the above by-laws information to provide accurate responses
+1. Use ONLY the above by-laws information to provide accurate responses
 2. If the question relates to parking regulations, zoning, or other topics covered in the by-laws, cite the specific by-law number
 3. If the information isn't contained in the provided by-laws, politely state that you don't have that specific information
-4. Provide clear, concise responses focused on the user's question
-5. Be professionally courteous as you represent the Town of Whitchurch-Stouffville
-6. Provide comprehensive answers that don't require follow-up questions - the user cannot respond to clarify details
-7. If a question requires specific information (like an address or location) to give a complete answer, provide information that covers all possible scenarios or explain what information would be needed and how the user can find this information themselves
-8. When applicable, include general information that applies to all streets/locations in Stouffville rather than asking for specific details
-9. Format your response using HTML for better presentation. You can use:
+4. DO NOT use any knowledge about by-laws that isn't explicitly provided in the input data - the by-laws here may differ from general knowledge
+5. If you're unsure or the answer is ambiguous based on the provided by-laws, clearly state that you cannot provide a definitive answer
+6. Provide clear, concise responses focused on the user's question
+7. Be professionally courteous as you represent the Town of Whitchurch-Stouffville
+8. Provide comprehensive answers that don't require follow-up questions - the user cannot respond to clarify details
+9. If a question requires specific information (like an address or location) to give a complete answer, provide information that covers all possible scenarios or explain what information would be needed and how the user can find this information themselves
+10. When applicable, include general information that applies to all streets/locations in Stouffville rather than asking for specific details
+11. Format your response using HTML for better presentation. You can use:
    - <h3> tags for section headings
    - <p> tags for paragraphs
    - <ul> and <li> tags for lists
@@ -48,14 +50,48 @@ I previously generated a response about Stouffville by-laws based on the user's 
 Today's date is """ + datetime.now().strftime("%B %d, %Y") + """.
 
 Your task is to review my previous response and create a new version that:
-1. REMOVES any mention of expired, temporary, or obsolete by-laws
-2. ONLY includes information about currently active by-laws
-3. If a by-law mentions an expiration date, a specific past date, or was for a temporary event that has passed, DO NOT include it
-4. If all relevant by-laws I mentioned have expired, politely state that you don't have specific information about current by-laws on this topic
-5. Keep all other relevant information that pertains to active by-laws
-6. Maintain the same professional tone and HTML formatting from my previous response
+1. Only REMOVES by-laws that are EXPLICITLY stated as expired, temporary with a passed end date, or repealed
+2. Keep ALL by-laws mentioned in the first response UNLESS there is clear evidence in the response that they are no longer applicable
+3. If a by-law doesn't explicitly mention an expiration date or repealed status, KEEP IT in your response
+4. Assume all by-laws mentioned are active unless explicitly stated otherwise
+5. If uncertain about whether a by-law is still active, include it in your response
+6. Keep all other relevant information that pertains to by-laws
+7. Maintain the same professional tone and HTML formatting from my previous response
+8. Do not add any information beyond what was in the first response
+9. Only base your response on the information contained in the first response, not on your general knowledge
+10. This is a best-effort process - when in doubt, include the information from the first response
+
+Your filtered response (in HTML format):"""
+)
+
+# Define a new prompt template for layman's terms explanation
+LAYMANS_PROMPT_TEMPLATE = PromptTemplate(
+    input_variables=["filtered_response", "question"],
+    template="""You are an AI assistant for the Town of Whitchurch-Stouffville, Ontario, Canada.
+            
+I previously generated a response about Stouffville by-laws based on the user's question. Here is my filtered response:
+
+<filtered_response>
+{filtered_response}
+</filtered_response>
+
+Today's date is """ + datetime.now().strftime("%B %d, %Y") + """.
+
+Your task is to create a concise, straightforward response that:
+1. Explains the information in clear, direct language for adults
+2. Keeps explanations brief and to the point - prioritize brevity
+3. Avoids unnecessary explanations, metaphors, or oversimplification
+4. Presents only the essential facts and practical information
+5. Uses a professional, respectful tone appropriate for adults
+6. Maintains the HTML formatting style
+7. IMPORTANT: Completely omits ALL references to by-laws, including by-law numbers, schedules, sections, or any other specific parts of bylaws
+8. Focuses only on what residents practically need to know
+9. States rules and regulations directly without mentioning their source in legal documents
+10. If information is unclear or missing in the filtered response, clearly state the limitations of what you can provide
+11. Do not add any information beyond what was in the filtered response - only simplify the existing information
+12. If you're uncertain about any information, clearly indicate this uncertainty in your response
 
 User Question: {question}
 
-Your filtered response (in HTML format):"""
+Your response (in HTML format):"""
 ) 

--- a/backend/app/templates/demo.html
+++ b/backend/app/templates/demo.html
@@ -99,7 +99,7 @@
         
         <div class="checkbox-container">
             <input type="checkbox" id="filter_expired" name="filter_expired" value="true" {% if compare_mode %}checked{% endif %} onchange="toggleComparisonOption()">
-            <label for="filter_expired"><strong>Show both answers for comparison</strong> (see how responses differ with and without expired by-laws)</label>
+            <label for="filter_expired"><strong>Show full prompt chain</strong> (see how responses evolve from technical to layman's terms)</label>
             
             <span class="comparison-option" id="comparisonOption">
                 <input type="checkbox" id="side_by_side" name="side_by_side" value="true" {% if side_by_side %}checked{% endif %}>
@@ -125,6 +125,12 @@
             <h3>Filtered Answer (active by-laws only)</h3>
             <p class="explanation" style="font-style: italic; color: #666;">This answer only includes currently active by-laws. Expired, temporary, or obsolete by-laws have been filtered out.</p>
             <div>{{ filtered_answer | safe }}</div>
+        </div>
+        
+        <div class="answer-container">
+            <h3>Simplified Answer (layman's terms)</h3>
+            <p class="explanation" style="font-style: italic; color: #666;">This answer presents the information in simple, everyday language that's easy for anyone to understand.</p>
+            <div>{{ laymans_answer | safe }}</div>
         </div>
         {% else %}
         <div class="answer-container">


### PR DESCRIPTION
This PR implements a new layman's terms feature that makes bylaw information more accessible to residents:

- Adds a third prompt that transforms technical legal language into plain, everyday language
- Removes all bylaw references from the simplified response
- Updates the demo interface to show all three responses (complete, filtered active, layman's terms)
- Modifies timing information to include the third prompt execution time
- Updates README documentation to reflect the new feature
- Prioritizes brevity in layman's explanations while maintaining professional tone

This feature improves overall user experience by providing information in a format that's easier for residents to understand without legal terminology.

Example output with new feature highlighted in yellow:
![image](https://github.com/user-attachments/assets/80ad3af5-cbc6-4129-9ee9-93c7b8b54c93)

