### PR TITLE
Standardize bylaw number format with YYYY-NNN pattern across extraction tools

### DIFF
--- a/tools/BatchParseAndExtractBylawPDFs.py
+++ b/tools/BatchParseAndExtractBylawPDFs.py
@@ -500,7 +500,7 @@ def extract_structured_data(api_key, file_uri, model="gemini-2.0-flash", rate_li
 
     prompt = """You are a fantastic parser of legal documents. You excel at reasoning while parsing and extracting. You follow instructions like a robot. You will validate the json produced against the PDF and the instructions provided before responding. For PDF file attached, produce a json file that has the below information
 
-bylawNumber: Bylaw alphanumeric code
+bylawNumber: Bylaw alphanumeric code in the format YYYY-NNN where YYYY is the year and NNN is a three-digit bylaw number (e.g., 2015-139)
 bylawYear: Bylaw year
 bylawType: Bylaws are numbered in a unique way. Ending with ZO could be zoning order, AP could be appointment, FI could be financial. Use your reasoning skills to define the type. Do not abbreviate.
 bylawHeader: The bolded text at the top of the document that forms part of the contiguous text that follows.

--- a/tools/IncrementalPDFExtraction.py
+++ b/tools/IncrementalPDFExtraction.py
@@ -40,7 +40,7 @@ Optional arguments:
 
 Output format:
     The script creates a JSON file for each PDF with the following schema elements:
-    - bylawNumber        : Bylaw alphanumeric code
+    - bylawNumber        : Bylaw alphanumeric code in the format YYYY-NNN where YYYY is the year and NNN is a three-digit bylaw number (e.g., 2015-001)
     - bylawYear          : Bylaw year
     - bylawType          : Type of bylaw based on code and content
     - bylawHeader        : Title or header of the document
@@ -1010,7 +1010,7 @@ def get_field_prompt(field_name, field_type, text_content):
     """
     # Define field-specific prompts based on the field name
     field_prompts = {
-        "bylawNumber": "Extract the bylaw alphanumeric code from the text.",
+        "bylawNumber": "Extract the bylaw alphanumeric code from the text in the format YYYY-NNN where YYYY is the year and NNN is a three-digit bylaw number (e.g., 2015-001).",
         "bylawYear": "Extract the bylaw year from the text.",
         "bylawType": "Analyze the bylaw number and content to determine the type. Bylaws are numbered in a unique way. Ending with ZO could be zoning order, AP could be appointment, FI could be financial. Use your reasoning skills to define the type. Do not abbreviate.",
         "bylawHeader": "Extract the bolded text at the top of the document that forms part of the contiguous text that follows.",


### PR DESCRIPTION
This PR adds explicit format requirements for bylaw numbers to improve data consistency across the system.

### Changes
- Added format specifications to bylaw number extraction in `BatchParseAndExtractBylawPDFs.py`
- Updated corresponding format guidance in `IncrementalPDFExtraction.py`
- Enhanced system's ability to recognize, validate, and auto-fix bylaw numbers following the YYYY-NNN pattern
- Maintains compatibility with the validation and auto-fixing capabilities added previously

### Benefits
- Ensures consistent bylaw number format (YYYY-NNN) across all extraction tools
- Improves accuracy of bylaw retrieval by standardizing the format expected by LLMs
- Reduces errors in bylaw identification and cross-referencing
- Clarifies requirements for developers and maintainers
