### PR TITLE
Replace deprecated model with new gemini-mixed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,17 @@ This project uses Google's Gemini AI models through the LangChain framework. Mak
 The application leverages ChromaDB (version 0.6.3) for vector search with Voyage AI embeddings to efficiently retrieve relevant by-laws based on semantic similarity.
 
 Available Gemini models:
+- gemini-mixed (uses best model for each query stage)
 - gemini-2.0-flash-lite (fastest, lowest cost)
-- gemini-2.0-flash (balanced speed/quality, default)
-- gemini-2.0-flash-thinking-exp-01-21 (better reasoning)
+- gemini-2.0-flash (balanced speed/quality)
 - gemini-2.5-flash-preview-04-17 (fast, high quality)
 - gemini-2.5-pro-exp-03-25 (highest quality, most expensive)
+
+When using the gemini-mixed option:
+- Query transformation uses gemini-2.0-flash
+- First query (bylaws) uses gemini-2.5-flash-preview-04-17
+- Second query (filtered) uses gemini-2.0-flash
+- Third query (layman's terms) uses gemini-2.0-flash
 
 Each prompt type uses a specific temperature setting for optimal results:
 - Bylaws prompt: 0.0 (consistent, deterministic outputs)

--- a/backend/README.md
+++ b/backend/README.md
@@ -233,11 +233,17 @@ The system uses a cost-efficient multi-step approach for processing by-laws info
 
 The backend supports multiple Gemini model options:
 
+- `gemini-mixed`: Uses the best model for each query stage (default)
 - `gemini-2.0-flash-lite`: Fastest, lowest cost option
-- `gemini-2.0-flash`: Default model with balanced speed and quality
-- `gemini-2.0-flash-thinking-exp-01-21`: Better reasoning capabilities
+- `gemini-2.0-flash`: Balanced speed and quality
 - `gemini-2.5-flash-preview-04-17`: Fast, high quality option
 - `gemini-2.5-pro-exp-03-25`: Highest quality, but most expensive
+
+The gemini-mixed option selects different models for different processing stages:
+- Query transformation: Uses `gemini-2.0-flash` for efficient query enhancement
+- First query (bylaws): Uses `gemini-2.5-flash-preview-04-17` for highest quality initial response
+- Second query (filtered): Uses `gemini-2.0-flash` for efficient filtering of expired bylaws
+- Third query (layman's terms): Uses `gemini-2.0-flash` for balanced quality/speed in final simplification
 
 Each prompt type uses a specific temperature setting for optimal results:
 - Bylaws prompt: 0.0 (consistent, deterministic outputs)

--- a/backend/app.py
+++ b/backend/app.py
@@ -266,7 +266,7 @@ def demo():
                 error_message = f"Error: ChromaDB retrieval failed: {str(e)}"
                 return render_template('demo.html', question=query, answer=error_message, model=model)
     
-    return render_template('demo.html', compare_mode=False, side_by_side=False, model="gemini-2.0-flash", bylaws_limit=10, enhanced_search=False)
+    return render_template('demo.html', compare_mode=False, side_by_side=False, model="gemini-mixed", bylaws_limit=10, enhanced_search=False)
 
 @app.route('/api/bylaw/<bylaw_number>')
 def get_bylaw_json(bylaw_number):

--- a/backend/app/templates/demo.html
+++ b/backend/app/templates/demo.html
@@ -14,9 +14,9 @@
         <div style="margin: 15px 0;">
             <label for="model">Select model:</label>
             <select id="model" name="model">
+                <option value="gemini-mixed" {% if model == "gemini-mixed" or not model %}selected{% endif %}>gemini-mixed (use best model for each query)</option>
                 <option value="gemini-2.0-flash-lite" {% if model == "gemini-2.0-flash-lite" %}selected{% endif %}>gemini-2.0-flash-lite (fastest, lowest cost)</option>
-                <option value="gemini-2.0-flash" {% if model == "gemini-2.0-flash" or not model %}selected{% endif %}>gemini-2.0-flash (balanced speed/quality)</option>
-                <option value="gemini-2.0-flash-thinking-exp-01-21" {% if model == "gemini-2.0-flash-thinking-exp-01-21" %}selected{% endif %}>gemini-2.0-flash-thinking-exp-01-21 (better reasoning)</option>
+                <option value="gemini-2.0-flash" {% if model == "gemini-2.0-flash" %}selected{% endif %}>gemini-2.0-flash (balanced speed/quality)</option>
                 <option value="gemini-2.5-flash-preview-04-17" {% if model == "gemini-2.5-flash-preview-04-17" %}selected{% endif %}>gemini-2.5-flash-preview-04-17 (even better reasoning)</option>
                 <option value="gemini-2.5-pro-exp-03-25" {% if model == "gemini-2.5-pro-exp-03-25" %}selected{% endif %}>gemini-2.5-pro-exp-03-25 (highest quality, most expensive)</option>
             </select>

--- a/backend/app/token_counter.py
+++ b/backend/app/token_counter.py
@@ -9,9 +9,9 @@ from app.prompts import (
 
 # Model pricing information (cost per 1M tokens)
 MODEL_PRICING = {
+    "gemini-mixed": {"input": 0.15, "output": 2.00},  # Estimated cost for gemini-mixed
     "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
     "gemini-2.0-flash-lite": {"input": 0.07, "output": 0.30},
-    "gemini-2.0-flash-thinking-exp-01-21": {"input": 0.10, "output": 2.00},
     "gemini-2.5-pro-exp-03-25": {"input": 1.25, "output": 10.00}
 }
 


### PR DESCRIPTION
This PR removes the the `gemini-2.0-flash-thinking-exp-01-21` model that Google deprecated and implements a new `gemini-mixed` option that intelligently uses different models for different stages of query processing:

- Removes all references to the deprecated `gemini-2.0-flash-thinking-exp-01-21` model from:
  - Model selection dropdown in demo.html
  - ALLOWED_MODELS list in gemini_handler.py
  - MODEL_PRICING dictionary in token_counter.py
  - README documentation

- Adds the new `gemini-mixed` option as the default model selection, which:
  - Uses `gemini-2.0-flash` for query transformation
  - Uses `gemini-2.5-flash-preview-04-17` for the first query (bylaws processing)
  - Uses `gemini-2.0-flash` for the second query (filtered processing)
  - Uses `gemini-2.0-flash` for the third query (layman's terms)

- Refactors the model selection code to make it more maintainable
- Updates pricing estimates in token_counter.py
- Updates documentation in both README files

This mixed-model approach offers improved performance by selecting the optimal model for each specific task, providing better quality where it matters most while keeping costs reasonable.
```
