### PR TITLE
Add bylaw number search and fix keyword search functionality

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -305,6 +305,7 @@ The `search_bylaws.py` script allows you to search the ChromaDB database using s
 Key features:
 - Semantic search using natural language queries
 - Keyword search within by-law metadata fields
+- Search by-laws by their bylaw number (case insensitive)
 - Display database statistics including by-law types and years
 - Calculate token usage and estimated LLM costs
 - Save search results to a JSON file
@@ -317,6 +318,7 @@ python search_bylaws.py [OPTIONS]
 Options:
 - `--query`: Natural language query for semantic search
 - `--keyword`: Keyword to search for in by-law metadata
+- `--bylaw-number`: Search for bylaws containing this string in their bylaw number (case insensitive)
 - `--limit`: Maximum number of results to return (default: 10)
 - `--output`: Output file name (default: search_results.json)
 - `--api-key`: Voyage AI API key (can also be set in .env file)
@@ -325,7 +327,7 @@ Options:
 - `--collection`: Collection name (default: by-laws)
 - `--stats`: Display database statistics
 
-At least one of `--query`, `--keyword`, or `--stats` is required.
+At least one of `--query`, `--keyword`, `--bylaw-number`, or `--stats` is required.
 
 ## Integration with the Application
 


### PR DESCRIPTION
## Changes
- Added new `--bylaw-number` search functionality to find bylaws by their number (case insensitive)
- Fixed bug in keyword search where string-format keywords were not being detected
- Updated README.md documentation to reflect new functionality

## Features
### New Bylaw Number Search
- Search bylaws using any part of their bylaw number
- Case insensitive matching (e.g., "33" matches "1933-056-MK", "2005-330-GO", "2010-033")
- Integrates seamlessly with existing search options

### Keyword Search Bug Fix
- Fixed issue where keywords stored as space-separated strings weren't being detected
- Now properly handles both list and string format keywords
- Example: Searching for "Veterinarian" now correctly finds bylaws with that keyword

## Testing
Tested with various scenarios:
- Bylaw number search with different number patterns
- Keyword search with string-format keywords
- Combined searches using multiple options
- Verified correct handling of case sensitivity

## Documentation
- Added new `--bylaw-number` option to README.md
- Updated usage examples and requirements
- Clarified search capabilities in documentation