### PR TITLE
Bring back the support for old sample database without the isActive metadata fields

### DIFF
--- a/backend/app/chroma_retriever.py
+++ b/backend/app/chroma_retriever.py
@@ -59,12 +59,14 @@ class ChromaDBRetriever:
             # Start timing the retrieval
             start_time = time.time()
             
-            # Use similarity_search directly instead of retriever
-            documents = self.vector_store.similarity_search(
+            # Use similarity_search without filter to improve performance, then filter in memory
+            raw_documents = self.vector_store.similarity_search(
                 query,
-                k=limit,
-                filter={"isActive": True}
+                k=limit * 5  # Retrieve more documents than needed to ensure we have enough after filtering
             )
+            
+            # Filter documents in memory: include docs with isActive=True OR docs without isActive field
+            documents = [doc for doc in raw_documents if "isActive" not in doc.metadata or doc.metadata["isActive"]][:limit]
             
             # Calculate retrieval time
             retrieval_time = time.time() - start_time


### PR DESCRIPTION
@thotapraneetha You will like this :)   Thanks to this code, your old small sample ChromaDB database will still work. This fix will correctly process any bylaws without the `isActive` field in them.

It also fixes the performance regression. It turned out the `filter={"isActive": True}` in the `similarity_search()` function was very slow -- it was taking 0.9 seconds instead of the usual 0.2 seconds. It turns out that this is a known issue in ChromaDB that is related to it not having the column indexing feature.  They are planning to add this feature in a future release, but this code fixes this problem for us. 