### PR TITLE
Simplified bylaw viewer retrieval code and improved how bylaw number is displayed in the viewer

### DIFF
--- a/backend/app/static/bylawViewer.js
+++ b/backend/app/static/bylawViewer.js
@@ -112,8 +112,20 @@ function displayBylaw(bylaw) {
     // Create the bylaw header
     const header = document.createElement('div');
     header.className = 'bylaw-header';
+    
+    // Use bylawFileName if available, otherwise fallback to bylawNumber
+    // Remove the '.json' extension if present
+    let displayTitle = bylaw.bylawNumber;
+    if (bylaw.bylawFileName) {
+        displayTitle = bylaw.bylawFileName;
+        // Remove .json extension if it exists
+        if (displayTitle.endsWith('.json')) {
+            displayTitle = displayTitle.slice(0, -5); // Remove last 5 characters ('.json')
+        }
+    }
+    
     header.innerHTML = `
-        <h2 class="bylaw-title">${bylaw.bylawNumber}</h2>
+        <h2 class="bylaw-title">${displayTitle}</h2>
         <h3 class="bylaw-subtitle">${bylaw.bylawType} (${bylaw.bylawYear})</h3>
     `;
     contentArea.appendChild(header);


### PR DESCRIPTION
## Changes
### Code cleanup
Since we fixed the bylaw numbers in our metadata, we can remove all that code that was trying to guess the correct bylaw number.

### Bylaw Viewer enhancement
To show more accurate and full bylaw names, we now use the `bylawFileName` to display the bylaw name in the Viewer.


### Screenshot
![image](https://github.com/user-attachments/assets/d07e5c6d-30a9-4c70-ba4f-5ffd3ca5455b)
