### PR TITLE
Voice recording support & HTTPS demo enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This project uses Docker to create a consistent development environment. The set
    - Access the demo web interface at http://localhost:5000/api/demo
    - Access the public demo interface at http://localhost:5000/public-demo
    - View specific bylaws at http://localhost:5000/static/bylawViewer.html?bylaw=BYLAW-NUMBER
+   - Record voice questions via the "Record Voice Question" button on the demo page over HTTPS: https://localhost:5443/api/demo
 
 ### Development Workflow
 
@@ -107,6 +108,9 @@ This project uses Docker to create a consistent development environment. The set
 - `POST /api/autocomplete`: Returns autocomplete suggestions for partial queries
   - Requires JSON with a 'query' field containing the partial query text
   - Returns semantically similar questions when the query is at least 3 characters long
+- `POST /api/voice_query`: Processes a base64-encoded audio recording for bylaw questions.
+  - Request JSON: `{ "audio_data": "<base64-encoded audio>", "mime_type": "<audio MIME type>" }`
+  - Response: `{ "transcript": "<transcribed question or NO_BYLAW_QUESTION_DETECTED>" }` or `{ "error": "<error message>" }`
 - `GET /public-demo`: Serves a simplified public-facing demo interface
 
 ### AI Integration

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This project uses Docker to create a consistent development environment. The set
    - Access the demo web interface at http://localhost:5000/api/demo
    - Access the public demo interface at http://localhost:5000/public-demo
    - View specific bylaws at http://localhost:5000/static/bylawViewer.html?bylaw=BYLAW-NUMBER
-   - Record voice questions via the "Record Voice Question" button on the demo page over HTTPS: https://localhost:5443/api/demo
+   - Record voice questions via the "Record Voice Question" button on the demo page over HTTPS: https://localhost:5000/api/demo (requires cert.pem and key.pem in the project root)
 
 ### Development Workflow
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -219,7 +219,7 @@ Frontend developers can directly use this production backend if they don't want 
 
    The server will run at:
    - http://localhost:5000 (HTTP)
-   - https://localhost:5443 (HTTPS; voice recording requires secure context)
+   - https://localhost:5000 (HTTPS; voice recording requires cert.pem and key.pem to enable secure context)
 
 3. **Integration with Frontend**
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -129,6 +129,32 @@ Returns autocomplete suggestions for a partial query, finding semantically simil
 
 Note: This endpoint returns an empty array if the query is less than 3 characters long.
 
+### POST `/api/voice_query`
+
+Processes a voice recording for bylaw questions.
+
+**Request Body:**
+```json
+{
+  "audio_data": "<base64-encoded audio>",
+  "mime_type": "<audio MIME type>"
+}
+```
+
+**Response (Success):**
+```json
+{
+  "transcript": "<transcribed question or NO_BYLAW_QUESTION_DETECTED>"
+}
+```
+
+**Response (Error):**
+```json
+{
+  "error": "<error message>"
+}
+```
+
 ### GET/POST `/api/demo`
 
 A standalone web demo page with a simple form interface:
@@ -148,6 +174,7 @@ The demo page includes:
 - Visualization of bylaws found specifically by enhanced search
 - Interactive sidebar to view full bylaw details directly from hyperlinks
 - "Problem? Log a bug!" buttons under each answer type that capture complete context for GitHub Issues
+- Voice recording button and form to record your question via microphone and auto-fill the input (requires HTTPS on port 5443).
 
 ### GET `/public-demo`
 
@@ -184,13 +211,15 @@ Frontend developers can directly use this production backend if they don't want 
 
    ```bash
    # Install dependencies
-   pip install flask flask-cors langchain langchain-google-genai langchain-chroma langchain-voyageai chromadb python-dotenv tiktoken
+   pip install flask flask-cors langchain langchain-google-genai langchain-chroma langchain-voyageai chromadb python-dotenv tiktoken cryptography
 
    # Run the application
    python app.py
    ```
 
-   The server will run at `http://localhost:5000`
+   The server will run at:
+   - http://localhost:5000 (HTTP)
+   - https://localhost:5443 (HTTPS; voice recording requires secure context)
 
 3. **Integration with Frontend**
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -419,6 +419,12 @@ def public_demo():
     """
     return app.send_static_file('public_demo.html')
 
+@app.route('/')
+def root():
+    """
+    Serve the public demo page as the default landing page.
+    """
+    return app.send_static_file('public_demo.html')
 
 @app.route('/api/provincial_laws', methods=['POST'])
 def provincial_laws():

--- a/backend/app.py
+++ b/backend/app.py
@@ -451,26 +451,20 @@ def voice_query():
     return jsonify({"transcript": result})
 
 if __name__ == '__main__':
-    from threading import Thread
-    from werkzeug.serving import run_simple
-
-    # Turn off the reloader so you don't get four threads
-    def serve_http():
-        run_simple(
-            '0.0.0.0', 5000, app,
-            use_reloader=False,
-            use_debugger=True
+    # Check if SSL certificate files exist
+    cert_file = 'cert.pem'
+    key_file = 'key.pem'
+    
+    if os.path.exists(cert_file) and os.path.exists(key_file):
+        # Use HTTPS with provided certificates
+        app.run(
+            host='0.0.0.0',
+            port=5000,
+            ssl_context=(cert_file, key_file),
+            debug=True
         )
-
-    def serve_https():
-        run_simple(
-            '0.0.0.0', 5443, app,
-            ssl_context='adhoc',
-            use_reloader=False,
-            use_debugger=True
-        )
-
-    Thread(target=serve_http).start()
-    Thread(target=serve_https).start()
+    else:
+        # Use standard HTTP
+        app.run(host='0.0.0.0', port=5000, debug=True)
 
 

--- a/backend/app/prompts.py
+++ b/backend/app/prompts.py
@@ -155,3 +155,79 @@ Your response should:
 
 Your response (in HTML format):"""
 )
+
+
+# Define the prompt to recognize questions asked using voice
+VOICE_PROMPT_TEMPLATE = PromptTemplate(
+    input_variables=["audio"],
+    template="""You are an AI assistant with advanced speech understanding capabilities. Your primary task is to process a raw audio file containing a user's spoken query. From this audio, you must:
+1.  Understand what the user is saying.
+2.  Identify if their query pertains to town bylaws for Whitchurch-Stouffville.
+3.  If it does, transform their potentially informal, hesitant, or verbose spoken words into a single, clear, concise, and grammatically correct question that can be directly used to query a bylaw information system.
+
+**Input:** You will receive a raw audio file (e.g., a WAV file) containing the user's voice. The user's speech in the audio might contain:
+*   Filler words (e.g., "um," "uh," "like," "you know")
+*   Hesitations or self-corrections
+*   Informal language or conversational pleasantries
+*   Potentially multiple related points or a rambling description
+
+**Your Goal:**
+1.  **Listen and Understand:** Accurately interpret the spoken content of the audio file.
+2.  **Identify Bylaw Intent:** Determine the primary bylaw-related information the user is seeking.
+3.  **Rephrase as a Question:** Formulate a direct, well-structured question that captures this intent.
+4.  **Clarity and Conciseness:** The question should be easy to understand and free of extraneous information derived from the speech.
+5.  **Focus on Bylaws:** Ensure the question is framed in a way that it can be answered by referring to town bylaws of Whitchurch-Stouffville.
+6.  **Grammar and Spelling:** The output question must be grammatically perfect and correctly spelled.
+
+**Instructions:**
+*   **DO:**
+    *   Mentally (or internally) transcribe and then refine the user's speech to extract the core query.
+    *   Remove all filler words, hesitations, and conversational fluff (e.g., "Hi there," "I was wondering," "Thanks") from the user's original utterance.
+    *   Focus solely on the part of the utterance that asks about a bylaw.
+    *   If the user mentions multiple aspects of a single bylaw topic in their speech, try to synthesize them into one coherent question if it makes sense.
+    *   If the user clearly asks multiple distinct bylaw questions, pick the most prominent or first clear bylaw-related question.
+    *   Assume the context is always about Whitchurch-Stouffville bylaws.
+    *   Output your response in the same language as the user's spoken input. If they speak in French, formulate the question in French. If they speak in English, formulate the question in English, etc.
+*   **DO NOT:**
+    *   Answer the question yourself.
+    *   Add any information that wasn't implied in the user's original spoken utterance.
+    *   Include any preamble like "The user wants to know..."
+    *   Output anything other than the reformulated question itself.
+    *   If the speech in the audio is entirely unrelated to bylaws (e.g., "What's the weather like?" or "Tell me a joke"), or if the audio is unintelligible (e.g., too noisy, silent, not speech), output the exact phrase: `NO_BYLAW_QUESTION_DETECTED`
+
+**Examples (Illustrating transformation from spoken words to question):**
+
+**Example 1:**
+*   User's Spoken Words (from audio): "Uh, hi, I was, um, wondering, like, can I park my, my big RV, you know, on my driveway for, like, the whole summer? Or is that not allowed?"
+*   Your Output: `Can I park an RV on my driveway for the entire summer?`
+
+**Example 2:**
+*   User's Spoken Words (from audio): "Yeah, so, about fences... what's the, uh, maximum height? And, um, do I need a permit for it or something?"
+*   Your Output: `What are the regulations for fence height and do I need a permit to build a fence?`
+
+**Example 3:**
+*   User's Spoken Words (from audio): "Good morning. My neighbor's dog, it uh, barks all the time, really loudly. Is there, like, a noise bylaw for that kinda thing?"
+*   Your Output: `Is there a noise bylaw that addresses excessive dog barking?`
+
+**Example 4:**
+*   User's Spoken Words (from audio): "Tell me about property standards. Specifically, what are the rules for, um, maintaining my lawn and, you know, keeping the yard tidy?"
+*   Your Output: `What are the property standards bylaws regarding lawn maintenance and yard tidiness?`
+
+**Example 5:**
+*   User's Spoken Words (from audio): "So, like, what's the best pizza place in town?"
+*   Your Output: `NO_BYLAW_QUESTION_DETECTED`
+
+**Example 6:**
+*   User's Spoken Words (from audio): (Audio is just static or heavy background noise with no discernible speech)
+*   Your Output: `NO_BYLAW_QUESTION_DETECTED`
+
+**Example 7:**
+*   User's Spoken Words (from audio): "Bonjour, est-ce que je peux, um, construire une clôture de deux mètres autour de ma propriété?"
+*   Your Output: `Est-ce que je peux construire une clôture de deux mètres autour de ma propriété?`
+
+---
+**[The user's audio file will be provided as input to you.]**
+
+**Reformulated Bylaw Question:**"""
+)
+

--- a/backend/app/prompts.py
+++ b/backend/app/prompts.py
@@ -56,7 +56,7 @@ When answering questions:
 13. Do NOT start your response with phrases like "Thank you for contacting" or "Thank you for your question"
 14. Do NOT end your response with phrases like "If you have any further questions" or "Feel free to ask"
 15. Directly answer the user's question without introductory or concluding sentences
-16. Use the same language as in the user's question when applicable
+16. CRITICAL: You MUST respond in the EXACT SAME LANGUAGE as the user's question. If the user asks in French, your ENTIRE response must be in French. If they ask in English, respond in English. If they ask in any other language, respond completely in that same language.
 
 User Question: {question}
 
@@ -103,7 +103,7 @@ Your task is to create a concise, straightforward response that:
 10. If information is unclear or missing in the filtered response, clearly state the limitations of what you can provide
 11. Do not add any information beyond what was in the filtered response - only simplify the existing information
 12. If you're uncertain about any information, clearly indicate this uncertainty in your response
-13. Use the same language as in the user's original question when applicable
+13. CRITICAL: You MUST respond in the EXACT SAME LANGUAGE as the user's original question. If the user asked in French, your ENTIRE response must be in French. If they asked in English, respond in English. If they asked in any other language, respond completely in that same language.
 
 User Question: {question}
 

--- a/backend/app/templates/demo.html
+++ b/backend/app/templates/demo.html
@@ -62,6 +62,12 @@
         </div>
         
         <input type="submit" value="Submit">
+        <button type="button" id="voiceBtn" style="background-color: orange; color: white; border: none; border-radius: 4px; padding: 8px 16px; cursor: pointer; margin-left: 10px;">Record Voice Question</button>
+        <div id="voiceForm" style="display: none; margin-top: 10px; padding: 10px; border: 1px solid #ccc; border-radius: 4px;">
+            <button type="button" id="startRecording">Start Recording</button>
+            <span id="recordingIndicator" style="display: none; color: red; font-weight: bold; margin-left: 10px;">Recording...</span>
+            <button type="button" id="stopRecording" style="display: none; margin-left: 10px;">Stop Recording</button>
+        </div>
         <button type="button" id="provincialLawsBtn" class="secondary-button">Get Provincial Laws Info</button>
         <div id="provincialLawsForm" style="display: none; margin-top: 10px; padding: 10px; border: 1px solid #ccc; border-radius: 4px;">
             <h3>Provincial Laws Information</h3>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ chromadb==0.6.3
 langchain-chroma==0.2.3
 langchain-voyageai==0.1.4
 tiktoken==0.8.0
+cryptography==45.0.2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       - ./database:/database  # Mount database directory
     ports:
       - "5000:5000"
+      - "5443:5443"
     restart: always
     environment:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,6 @@ services:
       - ./database:/database  # Mount database directory
     ports:
       - "5000:5000"
-      - "5443:5443"
     restart: always
     environment:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}


### PR DESCRIPTION
This PR introduces full voice-query functionality to the demo interface and enables secure HTTPS access alongside HTTP:

- **UI & JS**  
  - Adds a “Record Voice Question” button and hidden recording form to `demo.html`  
  - Implements MediaRecorder-based start/stop logic in `demo.js` (30 s auto-stop, secure-context detection, fallback alert)  
- **Backend**  
  - New `/api/voice_query` endpoint in `app.py`  
  - `process_voice_query` in `gemini_handler.py` uses `VOICE_PROMPT_TEMPLATE` to transcribe base64 audio via Gemini LLM  
- **HTTPS support**  
  - Configures Flask to serve HTTP on port 5000 and HTTPS (adhoc cert) on port 5443 in parallel  
  - **Note:** the adhoc (self-signed) certificate will trigger a browser warning; I'm planning to provision a real TLS certificate soon to remove this alert and deliver a seamless user experience  
  - Updates Docker Compose to expose both ports  
  - Adds `cryptography` to `requirements.txt` for ad-hoc SSL  
- **Documentation**  
  - Updates root `README.md` and `backend/README.md` with voice recording instructions, new endpoint, HTTPS demo URL, and dependency changes  

This allows users to record spoken questions directly in the demo (over HTTPS) while preserving existing HTTP access, with a plan to replace the self-signed cert with a trusted certificate in the near future.

